### PR TITLE
QA-3961 Check whether more limited nodetype than "nt:base" on query for list with active facets can be used

### DIFF
--- a/src/main/resources/jmix_list/html/list.hidden.load.jsp
+++ b/src/main/resources/jmix_list/html/list.hidden.load.jsp
@@ -1,15 +1,28 @@
+<%@ page import="org.jahia.services.render.Resource" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
 <%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
 <c:set var="facetParamVarName" value="N-${currentNode.name}"/>
+<c:set var="facetTargetType" value="N-type-${currentNode.name}"/>
 <c:set target="${moduleMap}" property="editable" value="true" />
 <%-- list mode --%>
 <c:choose>
     <c:when test="${not empty param[facetParamVarName] or currentResource.moduleParams.queryLoadAllUnsorted == 'true'}">
         <query:definition var="listQuery" >
-            <query:selector nodeTypeName="nt:base"/>
+            <c:choose>
+                <c:when test="${not empty param[facetTargetType]}">
+                    <query:selector nodeTypeName="${functions:decodeUrlParam(param[facetTargetType])}"/>
+                </c:when>
+                <c:when test="${not empty currentResource.moduleParams.facetListNodeType}">
+                    <query:selector nodeTypeName="${currentResource.moduleParams.facetListNodeType}"/>
+                </c:when>
+                <c:otherwise>
+                    <query:selector nodeTypeName="nt:base"/>
+                </c:otherwise>
+            </c:choose>
             <c:set var="descendantNode" value="${fn:substringAfter(currentNode.realNode.path,'/sites/')}"/>
             <c:set var="descendantNode" value="${fn:substringAfter(descendantNode,'/')}"/>
             <query:descendantNode path="/sites/${renderContext.site.name}/${descendantNode}"/>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-3961

## Description

These modification contain the following changes:
- The j:type property is used to determine the type to use instead of nt:base. If it cannot be properly resolved (for example because forked JSPs have not been updated) it will fallback to nt:base
- The FacetChoiceListInitializer has been improved to display only the properties for the j:type selected in the facet list. Also, hidden properties will no longer be displayed.
- Facet URL generation was modified to add a N-type-NODENAME URL query parameter that encodes the j:type value so that the list query may behave properly. This change requires updating forked JSP.
- The jmix:tagged type was added to the list of allowed types when selecting a facet type (note: it might be interesting to add more)
- The tag cloud was also improved to replace its usage of nt:base with jmix:tagged. Again, if this JSP was forked in projects it will require updating.


## Checklist

Impact of these changes for QA:
- Re-test all facet-related features (all facet types)
- Re-test tag clouds

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [x] User-facing Documentation
