### PR TITLE
QA-13129: Fix file unlocking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <export-package>org.jahia.modules.osgi</export-package>
         <jahia-module-type>system</jahia-module-type>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MC4CFQCHAVwFRG/2mSl0YaguqtcPanhVSgIVAJH4gNaqS7pf2efk3Yi8ydUFUvgJ</jahia-module-signature>
+        <jahia-module-signature>MC0CFQCXJ35cZ54rziyNo1KeGkPHhBlApAIUNf/gc0IsgYeG2vQVNsqzJsYvrr0=</jahia-module-signature>
     </properties>
 
     <dependencies>

--- a/src/main/resources/jnt_editableFile/html/editableFile.display.jsp
+++ b/src/main/resources/jnt_editableFile/html/editableFile.display.jsp
@@ -109,6 +109,7 @@
                         function saveSourceCode() {
                             disabled = $('#saveButton').prop('disabled');
                             if (!disabled) {
+                                $('#saveButton').prop('disabled', true);
                                 var data = {"sourceCode" : myCodeMirror.getValue(),
                                     "form-token" : document.forms['sourceForm'].elements['form-token'].value,
                                     "jcrMethodToCall":"put"};
@@ -117,7 +118,7 @@
                                     url: '${postURL}',
                                     data: data,
                                     success: function() {
-                                        $.get("<c:url value="${url.base}${currentNode.path}.unlock.do?type=editSource"/>",null,function() {
+                                        $.post("<c:url value="${url.base}${currentNode.path}.unlock.do?type=editSource"/>",null,function() {
                                             location.reload();
                                         });
                                     },


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/QA-13129

## Description
Since unlock action is restricted to HTTP POST, UI has to be updated accordingly; otherwise edited files will remain locked after edition.

Also disabled the save button when saveSourceCode() is triggered to avoid having the request sent twice when the button is clicked, because saveSourceCode() is also triggered on window blur event.
