### PR TITLE
QA-13915 : do not execute image extraction rule while importing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <export-package>org.jahia.modules.osgi</export-package>
         <jahia-module-type>system</jahia-module-type>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFAJJOAR26W0v4qSexhK4AU91esBzAhQv5rbkkPWNKxpqMHiAb0QTCF+93g==</jahia-module-signature>
+        <jahia-module-signature>MCwCFCVTQyYOFJJgkD6tcNInr3Cfs53BAhQlHVbX4vsCRCiytfsjqQKtCrDh/g==</jahia-module-signature>
     </properties>
 
     <dependencies>

--- a/src/main/resources/META-INF/rules.drl
+++ b/src/main/resources/META-INF/rules.drl
@@ -30,6 +30,7 @@ rule "Image update"
     when
         A file content has been modified
              - the mimetype matches image/.*
+             - not in operation import
     then
         > long timer = System.currentTimeMillis();
         Add the type jmix:image
@@ -40,4 +41,3 @@ rule "Image update"
         Dispose image
         Log "Image " + node.getPath() + " updated in " + (System.currentTimeMillis() - timer) + " ms"
 end
-


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-13915

This makes the rule to extract image information not executed in import.
As the extraction happened at the node creation, we don't need to do it once again when importing