### PR TITLE
Updated parent version to 8.1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.0.0</version>
+        <version>8.1.1.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
This is needed to fix an error with the default module not starting on Jahia 8.1.1.0-SNAPSHOT