### PR TITLE
BACKLOG-21315: Add jquery and assets modules dependencies, needed for jnt_editableFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <jahia-module-type>system</jahia-module-type>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFCtZqCvZWTF6O55QNBJaNZ+vPwFPAhQCwNSyYZGTUhhiVHzE4UmAI+5mjQ==</jahia-module-signature>
+        <jahia-depends>assets,jquery</jahia-depends>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21315

## Description

Without those two dependencies templates for jnt_module and jnt_editableFile are not rendering correctly as no resources are loaded
