### PR TITLE
BACKLOG-21763 : restore jquery in pager component

### DIFF
--- a/src/main/resources/jnt_pager/html/pager.jsp
+++ b/src/main/resources/jnt_pager/html/pager.jsp
@@ -13,6 +13,7 @@
 <%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+<template:addResources type="javascript" resources="jquery.min.js"/>
 <c:set var="boundComponent"
        value="${uiComponents:getBoundComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
 <c:if test="${not empty boundComponent and jcr:isNodeType(boundComponent, 'jmix:list')}">


### PR DESCRIPTION
The pager requires jQuery to work.
This PR to restore it.