### PR TITLE
QA-15401: Support custom template as j:menuItemView

### DIFF
--- a/src/main/resources/jnt_navMenu/html/navMenu.groovy
+++ b/src/main/resources/jnt_navMenu/html/navMenu.groovy
@@ -86,8 +86,9 @@ printMenu = { node, navMenuLevel, omitFormatting ->
 
 //                    print ("<h1>"+itemPath+closeUl+"</h1>")
                     listItemCssClass = (hasChildren ? "hasChildren" : "noChildren") + (inpath ? " inPath" : "") + (selected ? " selected" : "") + (index == 0 ? " firstInLevel" : "") + (index == nbOfChilds - 1 ? " lastInLevel" : "");
-                    Resource resource = new Resource(menuItem, "html", "menuElement", currentResource.getContextConfiguration());
-                    
+                    String menuItemTemplate = currentNode.properties['j:menuItemView']?.string ?: 'menuElement'
+                    Resource resource = new Resource(menuItem, "html", menuItemTemplate, currentResource.getContextConfiguration());
+
                     currentResource.getDependencies().add(menuItem.getCanonicalPath())
                     
                     def render = RenderService.getInstance().render(resource, renderContext)


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/QA-15401

## Description

Support a custom template, set as a `j:menuItemView` property, for the sub-menu items of the menu.

So with a template like:
![Screenshot 2025-01-30 at 15 45 25](https://github.com/user-attachments/assets/624ac918-045d-4310-b818-9245199d8ce6)

the following HTML can be generated using the custom template:
![Screenshot 2025-01-30 at 15 46 01](https://github.com/user-attachments/assets/1635b3cc-0123-498f-9ff2-48851889c2c7)
