### PR TITLE
fix: escape workflow title

### DIFF
--- a/src/main/resources/jnt_simpleWorkflow/html/simpleWorkflow.taskData.jsp
+++ b/src/main/resources/jnt_simpleWorkflow/html/simpleWorkflow.taskData.jsp
@@ -1,12 +1,14 @@
 <%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <template:tokenizedForm>
     <c:url value='${url.base}${currentNode.path}' var="url"/>
     <form id="taskDataForm_${currentNode.parent.identifier}" method="post" action="${url}">
         <input type="hidden" name="jcrMethodToCall" value="put"/>
         <div>
-            Title : <input size="50" type="title" name="jcr:title"
-                           value="${currentNode.properties['jcr:title'].string}"/>
+            <fmt:message key="label.title"/> : <input size="50" type="title" name="jcr:title"
+                           value="${fn:escapeXml(currentNode.properties['jcr:title'].string)}"/>
         </div>
     </form>
 </template:tokenizedForm>


### PR DESCRIPTION
Resolves https://github.com/Jahia/jahia-private/issues/4271
### Description
- remove non i18n text
- escape title

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
