### PR TITLE
chore: use proper StringUtils package name to remove plexus dependency

### DIFF
--- a/.chachalog/Rz8ALFfG.md
+++ b/.chachalog/Rz8ALFfG.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: patch
+---
+
+Use StringUtils from Apache commons lang3 to remove plexus dependency (#140)

--- a/src/main/java/org/jahia/modules/defaultmodule/actions/ChainAction.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/actions/ChainAction.java
@@ -15,7 +15,7 @@
  */
 package org.jahia.modules.defaultmodule.actions;
 
-import org.codehaus.plexus.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jahia.bin.*;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.render.RenderContext;

--- a/src/main/java/org/jahia/modules/defaultmodule/actions/GetWorkflowTasksAction.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/actions/GetWorkflowTasksAction.java
@@ -15,8 +15,6 @@
  */
 package org.jahia.modules.defaultmodule.actions;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.xerces.jaxp.SAXParserFactoryImpl;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -25,18 +23,9 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
 import org.jahia.services.workflow.WorkflowService;
 import org.jahia.services.workflow.WorklowTypeRegistration;
-import org.jahia.utils.Patterns;
 import org.json.JSONObject;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
### Description

Remove direct dependency to plexus-utils, by switching to `org.apache.commons.lang3.StringUtils`, instead of using the one from plexus. 

Also the `GetWorkflowTasksAction` class had a lot of unused imports, which I removed. Especially the xml related ones can raise errors when compiling with >=JDK9.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
