### PR TITLE
fix: roles with duplicate display names no longer lost in Server Roles list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.settings
 *.iml
 .idea
+.worktrees

--- a/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
@@ -99,7 +99,9 @@ public class RolesHandler implements Serializable {
         Map<JCRNodeWrapper, List<JCRNodeWrapper>> result = new TreeMap<JCRNodeWrapper, List<JCRNodeWrapper>>(new Comparator<JCRNodeWrapper>() {
             @Override
             public int compare(JCRNodeWrapper jcrNodeWrapper, JCRNodeWrapper jcrNodeWrapper2) {
-                return jcrNodeWrapper.getDisplayableName().compareTo(jcrNodeWrapper2.getDisplayableName());
+                int c = jcrNodeWrapper.getDisplayableName().compareTo(jcrNodeWrapper2.getDisplayableName());
+                if (c != 0) return c;
+                return jcrNodeWrapper.getPath().compareTo(jcrNodeWrapper2.getPath());
             }
         });
         final JCRSessionWrapper defaultSession = JCRSessionFactory.getInstance().getCurrentUserSession(null, locale, fallbackLocale);


### PR DESCRIPTION
## Summary

- `RolesHandler.getRoles()` builds a `TreeMap` keyed on `JCRNodeWrapper` with a comparator that sorts by `displayableName` only
- When two roles share the same `jcr:title`, `compareTo()` returns `0` → `TreeMap` treats them as the same key → second entry silently overwrites the first
- Fix adds JCR path as tiebreaker so all distinct roles are always retained

## Changes

`RolesHandler.java` comparator:
```java
// Before
return n1.getDisplayableName().compareTo(n2.getDisplayableName());

// After
int c = n1.getDisplayableName().compareTo(n2.getDisplayableName());
if (c != 0) return c;
return n1.getPath().compareTo(n2.getPath());
```

## Test plan

- [ ] Copy `server-administrator` role twice (both copies get same label)
- [ ] Open Administration → Users & Roles → Server Roles
- [ ] Verify all three roles appear in the list
- [ ] Rename one copy — verify display order updates correctly

Fixes https://github.com/Jahia/jahia-private/issues/5045