### PR TITLE
fix: restrict external-link href to an allow-list of URL schemes and escape it

### DIFF
--- a/.chachalog/f2Hq8xBw.md
+++ b/.chachalog/f2Hq8xBw.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: patch
+---
+
+External link component now restricts the rendered href to an allow-list of URL schemes (http, https, ftp, mailto, tel) and escapes the URL, so other schemes and special characters are handled safely.

--- a/src/main/resources/jnt_externalLink/html/externalLink.jsp
+++ b/src/main/resources/jnt_externalLink/html/externalLink.jsp
@@ -10,6 +10,9 @@
 <jcr:nodeProperty node="${currentNode}" name="j:target" var="target"/>
 
 <c:if test="${not empty description.string}"><c:set var="linkTitle"> title="${fn:escapeXml(description.string)}"</c:set></c:if>
-<c:if test="${not empty target.string}"><c:set var="target"> target="${target.string}"</c:set></c:if>
-<c:if test="${!functions:matches('^[A-Za-z]*:.*', url.string)}"><c:set var="protocol">http://</c:set></c:if>
-<a href="${protocol}${url.string}" ${target} ${linkTitle}>${fn:escapeXml(not empty title.string ? title.string : currentNode.name)}</a>
+<c:if test="${not empty target.string}"><c:set var="target"> target="${fn:escapeXml(target.string)}"</c:set></c:if>
+<%-- Only treat the value as an absolute URL when it uses a safe, allow-listed scheme; anything
+     else (including javascript:/data:/vbscript: and scheme-less values) is prefixed with http://
+     so unsafe schemes cannot reach the href. The href value is also HTML-escaped. --%>
+<c:if test="${!(functions:matches('(?i)^(https?|ftp)://.*', url.string) or functions:matches('(?i)^(mailto|tel):.*', url.string))}"><c:set var="protocol">http://</c:set></c:if>
+<a href="${protocol}${fn:escapeXml(url.string)}" ${target} ${linkTitle}>${fn:escapeXml(not empty title.string ? title.string : currentNode.name)}</a>


### PR DESCRIPTION
### Summary
The external-link component (`jnt:externalLink`) rendered the stored `j:url` straight into the `href`: any value that already contained a scheme (`something:`) was used verbatim, and the URL was **not HTML-escaped**. Values using an unusual scheme, or containing special characters, were therefore rendered incorrectly/unsafely.

### Change
`externalLink.jsp` now:
- treats the value as an absolute URL **only** when it uses an allow-listed scheme (`http`, `https`, `ftp`, `mailto`, `tel`); any other value (a non-allow-listed scheme, or a scheme-less value) is prefixed with `http://`, so non-allow-listed schemes can't reach the `href`;
- **HTML-escapes** the `href` value (and the `target` attribute).

### ⚠️ Risk / review notes (behavioral change — not a pure escape)
- A link using a scheme **outside** the allow-list (e.g. `sms:`, `geo:`, a custom app scheme) will now be prefixed with `http://` and no longer resolve as before. If such schemes are legitimately used, **extend the allow-list**. `mailto:`/`tel:`/`http(s)://`/`ftp://` are preserved.
- Please confirm the allow-list matches real external-link usage in your sites before merging.

### Verification
Deploy-tested on a local 8.2.x instance with a clean **before/after** (guest render): the baseline emitted a scheme value verbatim in the `href` and allowed an `href`-attribute breakout via a crafted value; this branch prefixes the disallowed scheme with `http://` (inert) and escapes the `href` (no breakout).
