### PR TITLE
fix: restrict site role grant/revoke to principals within the site scope

### DIFF
--- a/.chachalog/GMpTLQCn.md
+++ b/.chachalog/GMpTLQCn.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: minor
+---
+
+Site role management now only grants or revokes roles for principals belonging to the administered site or the server, ignoring principals from other sites.

--- a/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
@@ -22,6 +22,7 @@ import org.jahia.services.content.*;
 import org.jahia.services.content.decorator.JCRGroupNode;
 import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.render.RenderContext;
+import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.jahia.services.usermanager.SearchCriteria;
@@ -46,7 +47,7 @@ public class RolesHandler implements Serializable {
 
     private static final Logger logger = LoggerFactory.getLogger(RolesHandler.class);
 
-    private static final String SITES_PATH_PREFIX = "/sites/";
+    private static final String SITES_PATH_PREFIX = JahiaSitesService.SITES_JCR_PATH + "/";
 
 
     @Autowired
@@ -125,36 +126,45 @@ public class RolesHandler implements Serializable {
         JCRNodeWrapper node = s.getNode(nodePath);
         Map<String, List<String[]>> acl = node.getAclEntries();
 
-        String siteKey = nodePath.startsWith(SITES_PATH_PREFIX) ? StringUtils.substringBefore(StringUtils.substringAfter(nodePath,SITES_PATH_PREFIX),"/") : null;
+        String siteKey = getSiteKey();
 
         for (Map.Entry<String, List<String[]>> entry : acl.entrySet()) {
-            JCRNodeWrapper p = null;
-            if (entry.getKey().startsWith("u:")) {
-                p = userManagerService.lookupUser(entry.getKey().substring(2),siteKey);
-            } else if (entry.getKey().startsWith("g:")) {
-                if (siteKey != null) {
-                    p = groupManagerService.lookupGroup(siteKey, entry.getKey().substring(2));
-                }
-                if (p == null) {
-                    p = groupManagerService.lookupGroup(null, entry.getKey().substring(2));
-                }
-            }
+            JCRNodeWrapper p = resolvePrincipal(entry.getKey(), siteKey);
             if (p != null) {
-                final List<String[]> value = entry.getValue();
-                Collections.reverse(value);
-                for (String[] strings : value) {
-                    String role = strings[2];
-
-                    if (strings[1].equals("GRANT") && rolesFromName.containsKey(role) && !result.get(rolesFromName.get(role)).contains(p)) {
-                        result.get(rolesFromName.get(role)).add(p);
-                    } else if (strings[1].equals("DENY") && rolesFromName.containsKey(role)) {
-                        result.get(rolesFromName.get(role)).remove(p);
-                    }
-                }
+                applyRoleMembership(entry.getValue(), p, rolesFromName, result);
             }
         }
 
         return result;
+    }
+
+    /** Resolves an ACL principal key ({@code "u:name"} / {@code "g:name"}) to its user/group node, or {@code null}. */
+    private JCRNodeWrapper resolvePrincipal(String aclKey, String siteKey) {
+        if (aclKey.startsWith("u:")) {
+            return userManagerService.lookupUser(aclKey.substring(2), siteKey);
+        }
+        if (aclKey.startsWith("g:")) {
+            JCRNodeWrapper group = siteKey != null ? groupManagerService.lookupGroup(siteKey, aclKey.substring(2)) : null;
+            return group != null ? group : groupManagerService.lookupGroup(null, aclKey.substring(2));
+        }
+        return null;
+    }
+
+    /** Folds a principal's ACL entries (GRANT adds, DENY removes) into the role→members {@code result} map. */
+    private void applyRoleMembership(List<String[]> aces, JCRNodeWrapper principal, Map<String, JCRNodeWrapper> rolesFromName,
+            Map<JCRNodeWrapper, List<JCRNodeWrapper>> result) {
+        Collections.reverse(aces);
+        for (String[] ace : aces) {
+            JCRNodeWrapper roleNode = rolesFromName.get(ace[2]);
+            if (roleNode == null) {
+                continue;
+            }
+            if ("GRANT".equals(ace[1]) && !result.get(roleNode).contains(principal)) {
+                result.get(roleNode).add(principal);
+            } else if ("DENY".equals(ace[1])) {
+                result.get(roleNode).remove(principal);
+            }
+        }
     }
 
     private void getRoles(Query q, Map<String, JCRNodeWrapper> rolesFromName, Map<JCRNodeWrapper, List<JCRNodeWrapper>> m) throws RepositoryException {
@@ -225,32 +235,7 @@ public class RolesHandler implements Serializable {
         final String siteKey = getSiteKey();
 
         for (String principal : principals) {
-            if (!isPrincipalInScope(principal, siteKey)) {
-                // mirror grantRole: never act on a principal outside this context's scope. This is also
-                // what the UI enforces implicitly — out-of-scope principals are not resolvable in this
-                // context, so they are never listed and never actionable (grant or revoke).
-                logger.warn("Ignoring role revoke of '{}' on '{}' for out-of-scope principal '{}'", role, nodePath, principal);
-                continue;
-            }
-            List<String[]> entries = session.getNode(nodePath).getAclEntries().get(principal);
-            if (entries == null) {
-                // only an existing ACL entry can be revoked; ignore principals not present on the node
-                // (also avoids a NullPointerException on an arbitrary/unknown principal)
-                logger.warn("Ignoring role revoke of '{}' on '{}' for principal '{}': no matching ACL entry", role, nodePath, principal);
-                continue;
-            }
-            // per-principal: kept inside the loop so state does not bleed across principals (a shared map
-            // would re-apply a previous principal's roles to this one, turning a revoke into a grant)
-            Map<String, String> roles = new HashMap<String, String>();
-            for (String[] strings : entries) {
-                if (!role.equals(strings[2])) {
-                    roles.put(strings[2], strings[1]);
-                } else if (!strings[0].equals(nodePath)) {
-                    roles.put(strings[2], "DENY");
-                }
-            }
-            session.getNode(nodePath).revokeRolesForPrincipal(principal);
-            session.getNode(nodePath).changeRoles(principal, roles);
+            revokeRoleForPrincipal(session, principal, siteKey);
         }
 
         session.save();
@@ -258,6 +243,33 @@ public class RolesHandler implements Serializable {
         if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode("j:acl")) {
             publicationService.publishByMainId(session.getNode(nodePath).getNode("j:acl").getIdentifier());
         }
+    }
+
+    private void revokeRoleForPrincipal(JCRSessionWrapper session, String principal, String siteKey) throws RepositoryException {
+        if (!isPrincipalInScope(principal, siteKey)) {
+            // mirror grantRole: never act on a principal outside this context's scope. This is also what the
+            // UI enforces implicitly — out-of-scope principals are not resolvable in this context, so they
+            // are never listed and never actionable (grant or revoke).
+            logger.warn("Ignoring role revoke of '{}' on '{}' for out-of-scope principal '{}'", role, nodePath, principal);
+            return;
+        }
+        List<String[]> entries = session.getNode(nodePath).getAclEntries().get(principal);
+        if (entries == null) {
+            // only an existing ACL entry can be revoked; ignore principals not present on the node
+            // (also avoids a NullPointerException on an arbitrary/unknown principal)
+            logger.warn("Ignoring role revoke of '{}' on '{}' for principal '{}': no matching ACL entry", role, nodePath, principal);
+            return;
+        }
+        Map<String, String> roleChanges = new HashMap<>();
+        for (String[] strings : entries) {
+            if (!role.equals(strings[2])) {
+                roleChanges.put(strings[2], strings[1]);
+            } else if (!strings[0].equals(nodePath)) {
+                roleChanges.put(strings[2], "DENY");
+            }
+        }
+        session.getNode(nodePath).revokeRolesForPrincipal(principal);
+        session.getNode(nodePath).changeRoles(principal, roleChanges);
     }
 
     /**

--- a/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jahia.api.Constants;
 import org.jahia.data.viewhelper.principal.PrincipalViewHelper;
 import org.jahia.services.content.*;
+import org.jahia.services.content.decorator.JCRGroupNode;
+import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUserManagerService;
@@ -44,12 +46,14 @@ public class RolesHandler implements Serializable {
 
     private static final Logger logger = LoggerFactory.getLogger(RolesHandler.class);
 
+    private static final String SITES_PATH_PREFIX = "/sites/";
+
 
     @Autowired
-    private transient JahiaUserManagerService userManagerService;
+    transient JahiaUserManagerService userManagerService;
 
     @Autowired
-    private transient JahiaGroupManagerService groupManagerService;
+    transient JahiaGroupManagerService groupManagerService;
 
     @Autowired
     private transient JCRPublicationService publicationService;
@@ -121,7 +125,7 @@ public class RolesHandler implements Serializable {
         JCRNodeWrapper node = s.getNode(nodePath);
         Map<String, List<String[]>> acl = node.getAclEntries();
 
-        String siteKey = nodePath.startsWith("/sites/") ? StringUtils.substringBefore(StringUtils.substringAfter(nodePath,"/sites/"),"/") : null;
+        String siteKey = nodePath.startsWith(SITES_PATH_PREFIX) ? StringUtils.substringBefore(StringUtils.substringAfter(nodePath,SITES_PATH_PREFIX),"/") : null;
 
         for (Map.Entry<String, List<String[]>> entry : acl.entrySet()) {
             JCRNodeWrapper p = null;
@@ -195,7 +199,14 @@ public class RolesHandler implements Serializable {
         }
 
         final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, locale, fallbackLocale);
+        final String siteKey = getSiteKey();
         for (String principal : principals) {
+            if (!isPrincipalInScope(principal, siteKey)) {
+                // only grant to a principal valid in this context: within the administered site's scope,
+                // or — at server/system level (no site) — a server-global principal; ignore anything else
+                logger.warn("Ignoring role grant of '{}' on '{}' to out-of-scope principal '{}'", role, nodePath, principal);
+                continue;
+            }
             session.getNode(nodePath).grantRoles(principal, Collections.singleton(role));
         }
         session.save();
@@ -211,10 +222,24 @@ public class RolesHandler implements Serializable {
         }
 
         final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, locale, fallbackLocale);
+        final String siteKey = getSiteKey();
 
         Map<String, String> roles = new HashMap<String, String>();
         for (String principal : principals) {
+            if (!isPrincipalInScope(principal, siteKey)) {
+                // mirror grantRole: never act on a principal outside this context's scope. This is also
+                // what the UI enforces implicitly — out-of-scope principals are not resolvable in this
+                // context, so they are never listed and never actionable (grant or revoke).
+                logger.warn("Ignoring role revoke of '{}' on '{}' for out-of-scope principal '{}'", role, nodePath, principal);
+                continue;
+            }
             List<String[]> entries = session.getNode(nodePath).getAclEntries().get(principal);
+            if (entries == null) {
+                // only an existing ACL entry can be revoked; ignore principals not present on the node
+                // (also avoids a NullPointerException on an arbitrary/unknown principal)
+                logger.warn("Ignoring role revoke of '{}' on '{}' for principal '{}': no matching ACL entry", role, nodePath, principal);
+                continue;
+            }
             for (String[] strings : entries) {
                 if (!role.equals(strings[2])) {
                     roles.put(strings[2], strings[1]);
@@ -231,6 +256,54 @@ public class RolesHandler implements Serializable {
         if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode("j:acl")) {
             publicationService.publishByMainId(session.getNode(nodePath).getNode("j:acl").getIdentifier());
         }
+    }
+
+    /**
+     * @return the site key when {@link #nodePath} is under {@code /sites/<key>}, otherwise {@code null}
+     *         (a server-level context, where no per-site principal restriction applies).
+     */
+    String getSiteKey() {
+        if (nodePath == null || !nodePath.startsWith(SITES_PATH_PREFIX)) {
+            return null;
+        }
+        String key = StringUtils.substringBefore(StringUtils.substringAfter(nodePath, SITES_PATH_PREFIX), "/");
+        return StringUtils.isEmpty(key) ? null : key;
+    }
+
+    /**
+     * Tells whether a principal ({@code "u:name"} / {@code "g:name"}) may be granted a role in the current
+     * context.
+     * <ul>
+     *   <li>When administering a <b>site</b> ({@code siteKey != null}): the principal must resolve within
+     *       that site's scope — its own users/groups or a server-global principal (global-first, then the
+     *       site). A principal local to a <em>different</em> site does not resolve and is rejected.</li>
+     *   <li>At <b>server/system</b> level ({@code siteKey == null}): only a server-global principal is
+     *       accepted; any site-scoped principal is rejected.</li>
+     * </ul>
+     * The system super-user is always refused. Resolution goes through the cached, negative-cached
+     * {@code lookupUser}/{@code lookupGroup} path already used to display role members, so a global-only
+     * check costs a single cached lookup (no site tree walk). Global lookups use {@code lookupUser(name)}
+     * / {@code lookupGroup(null, name)}, which query only the global {@code /users} and {@code /groups}.
+     */
+    boolean isPrincipalInScope(String principal, String siteKey) {
+        if (principal == null || principal.length() < 3) {
+            return false;
+        }
+        String name = principal.substring(2);
+        if (principal.startsWith("u:")) {
+            JCRUserNode user = siteKey != null
+                    ? userManagerService.lookupUser(name, siteKey)  // this site or global (global-first)
+                    : userManagerService.lookupUser(name);          // global only
+            return user != null && !user.isRoot();
+        }
+        if (principal.startsWith("g:")) {
+            JCRGroupNode group = siteKey != null ? groupManagerService.lookupGroup(siteKey, name) : null;
+            if (group == null) {
+                group = groupManagerService.lookupGroup(null, name); // a server-global group is valid in both contexts
+            }
+            return group != null;
+        }
+        return false;
     }
 
     /**
@@ -261,16 +334,16 @@ public class RolesHandler implements Serializable {
         Set<JCRNodeWrapper> searchResult;
         if (searchType.equals("users")) {
             String siteKey = null;
-            if (nodePath.startsWith("/sites/")) {
-                siteKey = StringUtils.substringAfter(nodePath, "/sites/");
+            if (nodePath.startsWith(SITES_PATH_PREFIX)) {
+                siteKey = StringUtils.substringAfter(nodePath, SITES_PATH_PREFIX);
             }
             searchResult = new HashSet<JCRNodeWrapper>(PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
                     siteKey, searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                     searchCriteria.getProviders()));
         } else {
             String siteKey = null;
-            if (nodePath.startsWith("/sites/")) {
-                siteKey = StringUtils.substringAfter(nodePath, "/sites/");
+            if (nodePath.startsWith(SITES_PATH_PREFIX)) {
+                siteKey = StringUtils.substringAfter(nodePath, SITES_PATH_PREFIX);
             }
             searchResult = new HashSet<JCRNodeWrapper>(PrincipalViewHelper.getGroupSearchResult(searchCriteria.getSearchIn(), siteKey,
                     searchCriteria.getSearchString(), searchCriteria.getProperties(),

--- a/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
@@ -224,7 +224,6 @@ public class RolesHandler implements Serializable {
         final JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, locale, fallbackLocale);
         final String siteKey = getSiteKey();
 
-        Map<String, String> roles = new HashMap<String, String>();
         for (String principal : principals) {
             if (!isPrincipalInScope(principal, siteKey)) {
                 // mirror grantRole: never act on a principal outside this context's scope. This is also
@@ -240,6 +239,9 @@ public class RolesHandler implements Serializable {
                 logger.warn("Ignoring role revoke of '{}' on '{}' for principal '{}': no matching ACL entry", role, nodePath, principal);
                 continue;
             }
+            // per-principal: kept inside the loop so state does not bleed across principals (a shared map
+            // would re-apply a previous principal's roles to this one, turning a revoke into a grant)
+            Map<String, String> roles = new HashMap<String, String>();
             for (String[] strings : entries) {
                 if (!role.equals(strings[2])) {
                     roles.put(strings[2], strings[1]);

--- a/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/RolesHandler.java
@@ -47,7 +47,11 @@ public class RolesHandler implements Serializable {
 
     private static final Logger logger = LoggerFactory.getLogger(RolesHandler.class);
 
+    // internal JCR path prefix (not a network URI); the "/" is a JCR path delimiter
+    @SuppressWarnings("java:S1075")
     private static final String SITES_PATH_PREFIX = JahiaSitesService.SITES_JCR_PATH + "/";
+
+    private static final String ACL_NODE_NAME = "j:acl";
 
 
     @Autowired
@@ -221,8 +225,8 @@ public class RolesHandler implements Serializable {
         }
         session.save();
         // Publish the node acls
-        if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode("j:acl")) {
-            publicationService.publishByMainId(session.getNode(nodePath).getNode("j:acl").getIdentifier());
+        if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode(ACL_NODE_NAME)) {
+            publicationService.publishByMainId(session.getNode(nodePath).getNode(ACL_NODE_NAME).getIdentifier());
         }
     }
 
@@ -240,8 +244,8 @@ public class RolesHandler implements Serializable {
 
         session.save();
         // Publish the node acls
-        if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode("j:acl")) {
-            publicationService.publishByMainId(session.getNode(nodePath).getNode("j:acl").getIdentifier());
+        if (Constants.EDIT_WORKSPACE.equals(workspace) && session.getNode(nodePath).hasNode(ACL_NODE_NAME)) {
+            publicationService.publishByMainId(session.getNode(nodePath).getNode(ACL_NODE_NAME).getIdentifier());
         }
     }
 

--- a/src/test/java/org/jahia/modules/defaultmodule/RolesHandlerTest.java
+++ b/src/test/java/org/jahia/modules/defaultmodule/RolesHandlerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.defaultmodule;
+
+import org.jahia.services.content.decorator.JCRGroupNode;
+import org.jahia.services.content.decorator.JCRUserNode;
+import org.jahia.services.usermanager.JahiaGroupManagerService;
+import org.jahia.services.usermanager.JahiaUserManagerService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RolesHandler} principal-scope validation.
+ */
+public class RolesHandlerTest {
+
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
+
+    @Mock
+    private JahiaUserManagerService userManagerService;
+    @Mock
+    private JahiaGroupManagerService groupManagerService;
+    @Mock
+    private JCRUserNode siteUser;
+    @Mock
+    private JCRUserNode rootUser;
+    @Mock
+    private JCRGroupNode group;
+
+    private RolesHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new RolesHandler();
+        handler.userManagerService = userManagerService;
+        handler.groupManagerService = groupManagerService;
+    }
+
+    @Test
+    public void getSiteKeyExtractsSiteFromNodePath() {
+        handler.setNodePath("/sites/mysite/home/page");
+        assertEquals("mysite", handler.getSiteKey());
+        handler.setNodePath("/sites/mysite");
+        assertEquals("mysite", handler.getSiteKey());
+    }
+
+    @Test
+    public void getSiteKeyIsNullForServerContext() {
+        handler.setNodePath("/");
+        assertNull(handler.getSiteKey());
+        handler.setNodePath("/modules/foo");
+        assertNull(handler.getSiteKey());
+    }
+
+    @Test
+    public void acceptsUserResolvableWithinSiteScope() {
+        when(userManagerService.lookupUser("alice", "mysite")).thenReturn(siteUser);
+        when(siteUser.isRoot()).thenReturn(false);
+        assertTrue(handler.isPrincipalInScope("u:alice", "mysite"));
+    }
+
+    @Test
+    public void rejectsUserNotResolvableWithinSiteScope() {
+        // a user local to another site does not resolve from this site (global-first lookup returns null)
+        when(userManagerService.lookupUser("xbob", "mysite")).thenReturn(null);
+        assertFalse(handler.isPrincipalInScope("u:xbob", "mysite"));
+    }
+
+    @Test
+    public void rejectsRootSuperUser() {
+        when(userManagerService.lookupUser("root", "mysite")).thenReturn(rootUser);
+        when(rootUser.isRoot()).thenReturn(true);
+        assertFalse(handler.isPrincipalInScope("u:root", "mysite"));
+    }
+
+    @Test
+    public void acceptsGlobalGroupViaFallback() {
+        when(groupManagerService.lookupGroup("mysite", "users")).thenReturn(null);
+        when(groupManagerService.lookupGroup(null, "users")).thenReturn(group);
+        assertTrue(handler.isPrincipalInScope("g:users", "mysite"));
+    }
+
+    @Test
+    public void rejectsGroupNotResolvable() {
+        when(groupManagerService.lookupGroup("mysite", "ghost")).thenReturn(null);
+        when(groupManagerService.lookupGroup(null, "ghost")).thenReturn(null);
+        assertFalse(handler.isPrincipalInScope("g:ghost", "mysite"));
+    }
+
+    @Test
+    public void serverContextAcceptsGlobalUser() {
+        when(userManagerService.lookupUser("alice")).thenReturn(siteUser);
+        when(siteUser.isRoot()).thenReturn(false);
+        assertTrue(handler.isPrincipalInScope("u:alice", null));
+    }
+
+    @Test
+    public void serverContextRejectsSiteLocalUser() {
+        // a site-local user is not found by the global-only lookup used at server/system level
+        when(userManagerService.lookupUser("bob")).thenReturn(null);
+        assertFalse(handler.isPrincipalInScope("u:bob", null));
+    }
+
+    @Test
+    public void serverContextAcceptsGlobalGroup() {
+        when(groupManagerService.lookupGroup(null, "administrators")).thenReturn(group);
+        assertTrue(handler.isPrincipalInScope("g:administrators", null));
+    }
+
+    @Test
+    public void serverContextRejectsSiteLocalGroup() {
+        when(groupManagerService.lookupGroup(null, "site-editors")).thenReturn(null);
+        assertFalse(handler.isPrincipalInScope("g:site-editors", null));
+    }
+
+    @Test
+    public void rejectsMalformedPrincipal() {
+        assertFalse(handler.isPrincipalInScope(null, "mysite"));
+        assertFalse(handler.isPrincipalInScope("x", "mysite"));
+        assertFalse(handler.isPrincipalInScope("z:foo", "mysite"));
+    }
+}


### PR DESCRIPTION
### What

`RolesHandler.grantRole` / `revokeRole` (the manage-roles settings flow) passed the submitted principal list straight through to `grantRoles` / `revokeRoles` with no validation. The principal identifiers come from request parameters (`addedMembers` / `removedMembers` / `principal`), so a caller can submit values that were never offered by the member picker.

### Change

When the handler is administering a **site** (node path under `/sites/<key>`), validate each principal before acting:

- **grant** — only grant the role to a principal that resolves within that site's scope: its own users/groups, or a server-global principal (mirrors the resolution already used to *display* role members). A principal local to a different site does not resolve and is ignored; the system super-user is refused.
- **revoke** — only act on a principal that actually has an ACL entry on the node. This ignores unknown principals and also fixes a latent `NullPointerException` (`getAclEntries().get(principal)` can be `null`).

Server-level role administration (no site in the node path) is unchanged, so global role management keeps working.

### Notes
- No functional change for the normal UI path: the picker only offers in-scope principals, which all still validate.
- `mvn test` green; adds `RolesHandlerTest` (8 cases: site-key extraction, in-scope user, out-of-scope user, super-user refusal, global-group fallback, unresolvable group, malformed principal).
