### PR TITLE
fix: escape cssClass/target parameters in the nt:base link view

### DIFF
--- a/.chachalog/Vx7bN2Qk.md
+++ b/.chachalog/Vx7bN2Qk.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: minor
+---
+
+Escape the `cssClass` and `target` request parameters in the `nt:base` link view and restrict `target` to the standard frame keywords.

--- a/src/main/resources/nt_base/html/base.link.jsp
+++ b/src/main/resources/nt_base/html/base.link.jsp
@@ -6,7 +6,9 @@
 <jcr:nodeProperty node="${currentNode}" name="jcr:description" var="description"/>
 <c:if test="${not empty description.string}"><c:set var="linkTitle"> title="${fn:escapeXml(description.string)}"</c:set></c:if>
 </c:if>
-<c:if test="${not omitFormatting && not empty param.cssClass}"><c:set var="cssClass">${param.cssClass}</c:set></c:if>
+<c:if test="${not omitFormatting && not empty param.cssClass}"><c:set var="cssClass">${fn:escapeXml(param.cssClass)}</c:set></c:if>
+<c:set var="safeTarget" value="${fn:escapeXml(param.target)}"/>
+<c:if test="${not empty param.target && param.target ne '_blank' && param.target ne '_self' && param.target ne '_parent' && param.target ne '_top'}"><c:set var="safeTarget" value="_self"/></c:if>
 <c:choose>
     <c:when test='${jcr:isNodeType(currentNode, "nt:file")}'>
         <c:url var="urlValue" value="${currentNode.url}" context="/"/>
@@ -19,4 +21,4 @@
         <c:url var="urlValue" value="${url.base}${currentNode.path}.html"/>
     </c:otherwise>
 </c:choose>
-<c:if test="${not omitFormatting}"><span class="icon ${cssClass}"></span></c:if><a target="${param.target}" href="${urlValue}"${linkTitle}>${fn:escapeXml(not currentResource.moduleParams.useNodeNameAsTitle && not empty title.string ? title.string : currentNode.name)}</a>
+<c:if test="${not omitFormatting}"><span class="icon ${cssClass}"></span></c:if><a target="${safeTarget}" href="${urlValue}"${linkTitle}>${fn:escapeXml(not currentResource.moduleParams.useNodeNameAsTitle && not empty title.string ? title.string : currentNode.name)}</a>


### PR DESCRIPTION
### What

The `nt:base` `link` view (`nt_base/html/base.link.jsp`) wrote the ambient request parameters `cssClass` and `target` straight into the rendered HTML without encoding. This applies output encoding, consistent with how the same view already handles the title/description:

- `cssClass` → wrapped in `fn:escapeXml`.
- `target` → escaped with `fn:escapeXml` **and** allow-listed to the standard frame keywords (`_blank` / `_self` / `_parent` / `_top`), falling back to `_self` for anything else.

No behavior change for legitimate values; everything else in the view is untouched.