### PR TITLE
fix: escape editor-provided attribute values in navMenu, imageReferenceLink and componentLink views

### DIFF
--- a/.chachalog/MxrNq6YP.md
+++ b/.chachalog/MxrNq6YP.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: minor
+---
+
+Consistently HTML-escape editor-provided values rendered into HTML attributes in the navigation menu (`j:styleName`/`j:layoutID`), image reference link (`j:linkTitle`) and component link (`divClass`/`aClass`) views, matching the escaping already applied to the adjacent title/label fields.

--- a/src/main/resources/jnt_componentLink/html/componentLink.jsp
+++ b/src/main/resources/jnt_componentLink/html/componentLink.jsp
@@ -9,6 +9,6 @@
 <c:set var="boundComponent"
        value="${uiComponents:getBindedComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
 
-<div class="${currentNode.properties['divClass'].string}"><!--start preferences-->
-    <a title="${fn:escapeXml(currentNode.displayableName)}" class="${currentNode.properties['aClass'].string}" href="<c:url value='${url.base}${boundComponent.path}.${currentNode.properties["targetTemplate"].string}.html'/>">${fn:escapeXml(currentNode.displayableName)}</a>
+<div class="${fn:escapeXml(currentNode.properties['divClass'].string)}"><!--start preferences-->
+    <a title="${fn:escapeXml(currentNode.displayableName)}" class="${fn:escapeXml(currentNode.properties['aClass'].string)}" href="<c:url value='${url.base}${boundComponent.path}.${currentNode.properties["targetTemplate"].string}.html'/>">${fn:escapeXml(currentNode.displayableName)}</a>
 </div>

--- a/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
+++ b/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
@@ -28,12 +28,12 @@
     <c:set var="linknode" value="${linkreference.node}"/>
     <c:if test="${not empty linknode}">
         <c:url var="linkUrl" value="${url.base}${linknode.path}.html"/>
-        <c:set var="linkTitle"> title="${linknode.displayableName}"</c:set>
+        <c:set var="linkTitle"> title="${fn:escapeXml(linknode.displayableName)}"</c:set>
     </c:if>
     <c:if test="${empty linkUrl and not empty externalUrl}">
         <c:if test="${!functions:matches('^[A-Za-z]*:.*', externalUrl.string)}"><c:set var="protocol">http://</c:set></c:if>
         <c:url var="linkUrl" value="${protocol}${externalUrl.string}"/>
-        <c:if test="${not empty linkTitle.string}"><c:set var="linkTitle"> title="${linkTitle.string}"</c:set></c:if>
+        <c:if test="${not empty linkTitle.string}"><c:set var="linkTitle"> title="${fn:escapeXml(linkTitle.string)}"</c:set></c:if>
     </c:if>
     <c:if test="${!empty linkUrl}">
         <a href="${linkUrl}" ${target} ${linkTitle}>

--- a/src/main/resources/jnt_navMenu/html/navMenu.groovy
+++ b/src/main/resources/jnt_navMenu/html/navMenu.groovy
@@ -30,13 +30,13 @@ def printMenu;
 printMenu = { node, navMenuLevel, omitFormatting ->
     if (navMenuLevel == 1) {
         if (styleName) {
-            print("<div class=\"${styleName.string}\">")
+            print("<div class=\"${Functions.escapeXml(styleName.string)}\">")
         }
         if (title) {
             print("<span>${Functions.escapeXml(title.string)}</span>")
         }
         if (layoutID) {
-            print("<div id=\"${layoutID.string}\">")
+            print("<div id=\"${Functions.escapeXml(layoutID.string)}\">")
         }
     }
 

--- a/src/main/resources/jnt_navMenu/html/navMenu.old.jsp
+++ b/src/main/resources/jnt_navMenu/html/navMenu.old.jsp
@@ -52,12 +52,12 @@
 
 <c:set var="navMenuLevel" value="${empty currentResource.moduleParams.navMenuLevel ? 1 : currentResource.moduleParams.navMenuLevel}"/>
 <c:if test="${navMenuLevel == 1}">
-    <div class="${styleName.string}">
+    <div class="${fn:escapeXml(styleName.string)}">
     <c:if test="${not empty title.string}">
         <span><c:out value="${fn:escapeXml(title.string)}"/></span>
     </c:if>
     <c:if test="${!empty layoutID}">
-        <div id="${layoutID.string}">
+        <div id="${fn:escapeXml(layoutID.string)}">
     </c:if>
 </c:if>
 <c:if test="${not empty current}">

--- a/src/main/resources/jnt_navMenu/html/navMenu.oneLevel.jsp
+++ b/src/main/resources/jnt_navMenu/html/navMenu.oneLevel.jsp
@@ -65,10 +65,10 @@
 
 <%--render (id and class)--%>
 <c:if test="${!empty layoutID}">
-    <div id="${layoutID.string}">
+    <div id="${fn:escapeXml(layoutID.string)}">
 </c:if>
 <c:if test="${!empty styleName}">
-    <div class="${styleName.string}">
+    <div class="${fn:escapeXml(styleName.string)}">
 </c:if>
 
 

--- a/src/main/resources/jnt_navMenu/html/navMenu.simple.jsp
+++ b/src/main/resources/jnt_navMenu/html/navMenu.simple.jsp
@@ -65,10 +65,10 @@
 <%--render (id and class)--%>
 <c:if test="${navMenuLevel == 1}">
     <c:if test="${!empty layoutID}">
-        <div id="${layoutID.string}">
+        <div id="${fn:escapeXml(layoutID.string)}">
     </c:if>
     <c:if test="${!empty styleName }">
-        <div class="${styleName.string}">
+        <div class="${fn:escapeXml(styleName.string)}">
     </c:if>
 </c:if>
 


### PR DESCRIPTION
Editor-provided property values were rendered verbatim into HTML attributes in a few `default` views, while adjacent title/label fields in the same views were already HTML-escaped. This aligns the attribute rendering with that existing escaping:

- `jnt:navMenu` — `j:styleName` / `j:layoutID` into `class=`/`id=` (groovy default view + simple/oneLevel/old JSP views)
- `jnt:imageReferenceLink` — `j:linkTitle` (and the internal-link title) into the anchor `title=`
- `jnt:componentLink` — `divClass` / `aClass` into `class=`

Escaping-only change, no functional/behavioral impact for well-formed values.