### PR TITLE
fix: always check a chained action's own requirements against the caller

### DIFF
--- a/.chachalog/VdVk6BC.md
+++ b/.chachalog/VdVk6BC.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Chained actions are always checked against their own declared requirements, including when the chain runs with a system session (behaviour change: a chained action is now refused when the caller does not meet them)

--- a/src/main/java/org/jahia/modules/defaultmodule/actions/ChainAction.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/actions/ChainAction.java
@@ -73,14 +73,14 @@ public class ChainAction extends Action implements InitializingBean {
             String path = null;
             for (String actionToDo : actions) {
                 if (DefaultPostAction.ACTION_NAME.equals(actionToDo)) {
-                    checkRequirements(defaultPostAction, renderContext, urlResolver, session);
+                    checkRequirements(defaultPostAction, renderContext, urlResolver);
                     String s = urlResolver.getUrlPathInfo().replace(".chain.do", "/*");
                     URLResolver resolver = urlResolverFactory.createURLResolver(s,req.getServerName(), req);
                     resolver.setSiteKey(urlResolver.getSiteKey());
                     result = defaultPostAction.doExecute(req, renderContext, resource, session, parameters, resolver);
                 } else {
                     Action action = actionsMap.get(actionToDo);
-                    checkRequirements(action, renderContext, urlResolver, session);
+                    checkRequirements(action, renderContext, urlResolver);
                     result = action.doExecute(req, renderContext, resource, session, parameters, urlResolver);
                     if (actionToDo.equals("redirect") && result != null && result.getUrl() != null) {
                     	path = result.getUrl();
@@ -95,13 +95,16 @@ public class ChainAction extends Action implements InitializingBean {
         return ActionResult.BAD_REQUEST;
     }
 
-    private void checkRequirements(Action action, RenderContext renderContext, URLResolver urlResolver,
-            JCRSessionWrapper session) throws RepositoryException {
-        // check that the action is not executed as SystemAction
-        if (!session.isSystem()) {
-            // not a system action -> check all the requirements
-            Render.checkActionRequirements(action, renderContext, urlResolver);
-        }
+    private void checkRequirements(Action action, RenderContext renderContext, URLResolver urlResolver)
+            throws RepositoryException {
+        // Every action named in the chain has its own requirements checked, in every case.
+        //
+        // This deliberately does not consider whether the chain itself is running with a system
+        // session. That describes how this action was invoked, not who invoked it, so it cannot
+        // stand in for the caller's entitlement: a chain that was promoted upstream in the render
+        // pipeline would otherwise run every action it names with that action's own
+        // authentication, permission and workspace requirements left unchecked.
+        Render.checkActionRequirements(action, renderContext, urlResolver);
     }
 
     /**

--- a/src/test/java/org/jahia/modules/defaultmodule/actions/ChainActionTest.java
+++ b/src/test/java/org/jahia/modules/defaultmodule/actions/ChainActionTest.java
@@ -21,7 +21,6 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
 import org.jahia.services.templates.JahiaTemplateManagerService;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -57,11 +56,6 @@ public final class ChainActionTest {
     @Mock JCRSessionWrapper jcrSessionWrapper;
     @Mock URLResolver urlResolver;
 
-    @Before
-    public void setup() {
-        when(jcrSessionWrapper.isSystem()).thenReturn(false);
-    }
-
     @Test
     public void testAllActionsExecuted() throws Exception {
         Action action1 = mockAction("action1");
@@ -81,6 +75,32 @@ public final class ChainActionTest {
     @Test
     public void testProtectedActionIsNotExecutedWhenUnauthenticated() throws Exception {
         when(renderContext.isLoggedIn()).thenReturn(false);
+
+        Action action1 = mockAction("action1");
+        Action action2 = mockAction("action2", a -> when(a.isRequireAuthenticatedUser()).thenReturn(true));
+        registerActions(action1, action2);
+
+        ChainAction chainAction = new ChainAction();
+        chainAction.setTemplateService(templateService);
+
+        Map<String, List<String>> parameters = mapOf(ChainAction.CHAIN_OF_ACTION, Arrays.asList("action1,action2"));
+        Exception e = assertThrows(AccessDeniedException.class, () ->
+                chainAction.doExecute(httpRequest, renderContext, resource, jcrSessionWrapper, parameters, urlResolver)
+        );
+        assertEquals("Action 'action2' requires an authenticated user", e.getMessage());
+
+        verify(action1).doExecute(httpRequest, renderContext, resource, jcrSessionWrapper, parameters, urlResolver);
+        verify(action2, never()).doExecute(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testProtectedActionIsNotExecutedWhenUnauthenticatedEvenIfTheChainRunsWithASystemSession() throws Exception {
+        when(renderContext.isLoggedIn()).thenReturn(false);
+        // The chain can be handed a system session by the caller upstream. That describes how the
+        // chain was invoked, not who invoked it, so it must not relax the requirements declared by
+        // the actions the chain names. Lenient because the implementation is expected NOT to look
+        // at this at all — the stub states the scenario, it is not an expectation.
+        lenient().when(jcrSessionWrapper.isSystem()).thenReturn(true);
 
         Action action1 = mockAction("action1");
         Action action2 = mockAction("action2", a -> when(a.isRequireAuthenticatedUser()).thenReturn(true));


### PR DESCRIPTION
## Summary

`ChainAction` runs each action named in `chainOfAction`. Before running one it calls
`Render.checkActionRequirements`, which enforces that action's declared `requiredMethods`,
`requiredWorkspace`, `requireAuthenticatedUser` and `requiredPermission`.

That call was skipped whenever the chain itself happened to be executing with a system JCR session:

```java
private void checkRequirements(Action action, RenderContext renderContext, URLResolver urlResolver,
        JCRSessionWrapper session) throws RepositoryException {
    // check that the action is not executed as SystemAction
    if (!session.isSystem()) {
        // not a system action -> check all the requirements
        Render.checkActionRequirements(action, renderContext, urlResolver);
    }
}
```

Whether this action was handed a system session describes **how it was invoked**, not **who invoked
it**. The render pipeline can pass a system session down while the caller is an ordinary visitor, and
in that case every action the chain names ran with its own declared requirements unchecked.

The condition also contradicts the intent recorded when the check was introduced — `5e1b57c`,
*"Do not require authenticated user for the ChainAction, but rather properly check requirements of
each action in the chain"*. Checking each action was the point of that commit; this branch turned it
off, and it was added in the same change.

## Change

`checkRequirements` always delegates to `Render.checkActionRequirements`. The `session` parameter is
gone, because the session is not a valid input to this decision.

`Render.checkActionRequirements` already evaluates against the caller: `requireAuthenticatedUser`
against `renderContext.isLoggedIn()`, and `requiredPermission` through `Action.isPermitted`, which
resolves the user via `JCRSessionFactory.getCurrentUser()`. So the requirements are now checked
against whoever made the request, independently of the session the chain executes with.

## Behaviour change — please read before merging

**A chained action that declares requirements is now refused when the caller does not meet them, even
if the chain is executing with a system session.**

Are you affected? Only if a template posts to `*.chain.do` and depends on those checks being skipped.
Concretely, `chainOfAction=default` reaches `org.jahia.bin.DefaultPostAction`, which inherits
`requireAuthenticatedUser = true` from `Action`, so a caller that is not logged in now gets
`AccessDeniedException: Action 'default' requires an authenticated user` where the chain previously
went ahead. Logged-in callers are unaffected — `DefaultPostAction` declares no required permission and
no required workspace.

`chainOfAction` appears nowhere in the Jahia codebase outside `ChainAction` itself — it is a
project-level extension point (`@since JAHIA 6.5`) — so no shipped feature changes behaviour. A
project that chains actions for visitors who are not logged in needs to either give those visitors an
identity, or declare the chained action's requirements to match the access it intends.

## Verification

`mvn -o test` → **16 run / 0 failures** (12 `RolesHandlerTest`, 4 `ChainActionTest`).
`mvn -o -DskipTests clean package` builds (JDK 11).

`ChainActionTest` gains one case for the system-session scenario (see the diff for its name, which
follows the existing convention in that file). It is a real before/after rather than a restatement of
the new code:

- against the previous implementation it **fails** — `expected javax.jcr.AccessDeniedException to be
  thrown, but nothing was thrown`, i.e. the protected action ran unchecked;
- against this one it passes, and also asserts that the earlier action in the chain still ran while
  the protected one did not.

The three existing tests keep their behaviour and still pass. The `@Before` that pinned
`isSystem()` to `false` is removed: it existed only to keep the removed branch quiet, and under
strict stubs it would now fail as an unnecessary stubbing. It is also why that branch had no
coverage — every existing test drove the non-system path only.
