### PR TITLE
fix: escape and restrict image reference link href to an allow-list of URL schemes

### DIFF
--- a/.chachalog/ikXkg4T3.md
+++ b/.chachalog/ikXkg4T3.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+default: patch
+---
+
+Image reference link component now restricts the rendered href to an allow-list of URL schemes (http, https, ftp, mailto, tel) and escapes the URL, so other schemes and special characters are handled safely.

--- a/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
+++ b/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
@@ -39,7 +39,7 @@
         <c:if test="${not empty linkTitle.string}"><c:set var="linkTitle"> title="${fn:escapeXml(linkTitle.string)}"</c:set></c:if>
     </c:if>
     <c:if test="${!empty linkUrl}">
-        <a href="${linkUrl}" ${target} ${linkTitle}>
+        <a href="${fn:escapeXml(linkUrl)}" ${target} ${linkTitle}>
     </c:if>
 
     <img src="${imageUrl}" alt="${fn:escapeXml(not empty title.string ? title.string : currentNode.name)}" <c:out value="${height} ${width}" escapeXml="false"/> />

--- a/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
+++ b/src/main/resources/jnt_imageReferenceLink/html/imageReferenceLink.jsp
@@ -24,14 +24,17 @@
     <c:if test="${not empty node.properties['j:width']}">
         <c:set var="width">width="${node.properties['j:width'].string}"</c:set>
     </c:if>
-    <c:if test="${not empty target.string}"><c:set var="target"> target="${target.string}"</c:set></c:if>
+    <c:if test="${not empty target.string}"><c:set var="target"> target="${fn:escapeXml(target.string)}"</c:set></c:if>
     <c:set var="linknode" value="${linkreference.node}"/>
     <c:if test="${not empty linknode}">
         <c:url var="linkUrl" value="${url.base}${linknode.path}.html"/>
         <c:set var="linkTitle"> title="${fn:escapeXml(linknode.displayableName)}"</c:set>
     </c:if>
     <c:if test="${empty linkUrl and not empty externalUrl}">
-        <c:if test="${!functions:matches('^[A-Za-z]*:.*', externalUrl.string)}"><c:set var="protocol">http://</c:set></c:if>
+        <%-- Only treat the value as an absolute URL when it uses a safe, allow-listed scheme; anything
+             else (including javascript:/data:/vbscript: and scheme-less values) is prefixed with http://
+             so unsafe schemes cannot reach the href. The href value is also HTML-escaped. --%>
+        <c:if test="${!(functions:matches('(?i)^(https?|ftp)://.*', externalUrl.string) or functions:matches('(?i)^(mailto|tel):.*', externalUrl.string))}"><c:set var="protocol">http://</c:set></c:if>
         <c:url var="linkUrl" value="${protocol}${externalUrl.string}"/>
         <c:if test="${not empty linkTitle.string}"><c:set var="linkTitle"> title="${fn:escapeXml(linkTitle.string)}"</c:set></c:if>
     </c:if>


### PR DESCRIPTION
### Description
Similar to https://github.com/Jahia/default/pull/146 but for the image reference link (`jnt:imageReferenceLink`) component.

**⚠️ Breaking changes ⚠️**
It contains the same behavioural change:
- A link using a scheme outside the allow-list (e.g. sms:, geo:, a custom app scheme) will now be prefixed with http:// and no longer resolve as before. If such schemes are legitimately used, extend the allow-list. mailto:/tel:/http(s):///ftp:// are preserved.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
