### PR TITLE
fix: render the roles screen only for callers administering the resource

### DIFF
--- a/.chachalog/aKivWdQN.md
+++ b/.chachalog/aKivWdQN.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Render the roles screen only for callers administering the resource

--- a/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
+ *
+ * Jahia's engineering conventions (the shared `cortex` harness, skill
+ * `jahia-java-osgi-declarative-services`) state the rule as: DS is the ONLY dependency-injection
+ * mechanism allowed in a Jahia module — Blueprint is deprecated and Spring is forbidden, with the sole
+ * tolerated exception being a guarded `SpringContextSingleton.getBean(...)` read-through to a core bean.
+ * An earlier revision of this filter was registered as a Spring bean in META-INF/spring; it was moved
+ * here to follow that rule, and the render filter it registers behaves identically either way (both end
+ * up in JahiaTemplateManagerService.getRenderFilters()).
+ *
+ * The same harness documents the trap to watch for if this is ever ported to another module: without the
+ * bnd instruction `<_dsannotations>*</_dsannotations>`, an @Component class compiles and ships but emits
+ * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
+ * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
+ * do not. Verify a descriptor is actually in the built jar rather than assuming.
+ */
 package org.jahia.modules.defaultmodule;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,77 +38,84 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Renders a settings component only when the caller holds an administration permission on the
- * resource the request is actually made against.
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
  * <p>
  * The role-management screen is an ordinary, instantiable content type, so the settings container it was
  * designed for is not the only place it can be rendered from. The permission requirement is declared on the
- * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}) and is therefore a property of
- * that template: the same component rendered through any other resource — a plain page content area — carries
- * no requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
- * filter makes the requirement a property of the component, so it holds on every render path.
+ * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}), so it is a property of that
+ * template and not of the component: the same component rendered through any other resource — a plain page
+ * content area — carries no requirement at all, and the web flow behind it would be handed to whoever can
+ * render that resource. This filter makes the requirement a property of the component, so it holds on every
+ * render path.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and for this screen that is essential rather than incidental. {@code jnt:manageRoles} is hosted by
- * <em>both</em> administration routes — siteSettings registers it as {@code roleGroup="site-role"} under
- * {@code siteAdminSiteRoles}, serverSettings as server- and system-role — so a site-scoped administrator is a
- * legitimate caller. Their role is granted on {@code /sites/<key>}, while the component node of the
- * legitimate screen lives inside the hosting module ({@code /modules/...}), where they hold nothing. Checking
- * the component node would therefore refuse them; the main resource is the site (or the global settings node
- * for the server route), which is what each administrator role is actually granted on.
+ * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
+ * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
+ * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
+ * the component node, which is the obvious implementation, would therefore refuse real site administrators.
+ * The main resource is the site (site-settings route) or the global settings node (server-administration
+ * route), which is what the corresponding administrator role is actually granted on.
  * <p>
- * Either administration permission is accepted for the same reason. Both are core permissions
- * ({@code root-permissions.xml}) granted by the {@code site-administrator} / {@code server-administrator}
- * roles; the finer per-screen requirement remains enforced on the administration route by the template, so
- * this filter is an additional condition and never a replacement. Failing to resolve a main resource, or a
- * missing configuration, yields an empty fragment rather than a rendered component.
+ * Either {@code site-admin} or {@code admin} is accepted because {@code jnt:manageRoles} is hosted by both
+ * administration routes: siteSettings registers it as {@code roleGroup="site-role"} under
+ * {@code siteAdminSiteRoles}, serverSettings as server- and system-role. A site-scoped administrator is
+ * therefore a legitimate caller. Both are core permissions ({@code root-permissions.xml}).
+ * The finer per-screen requirement declared on the settings template remains enforced on the administration
+ * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
+ * yields an empty fragment rather than a rendered component.
+ * <p>
+ * Registered via OSGi Declarative Services — no Spring context involvement.
  */
-// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines equality as
-// (concrete class, priority), which is the key RenderService.addFilter uses to replace an already-registered
-// filter. Widening it to the configuration would break that re-registration.
-@SuppressWarnings("java:S2160")
+@Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    private String[] requiredPermissions = new String[0];
-    private String requiredPermissionsLabel = "";
+    /** Node types gated by this filter. */
+    private static final String APPLY_ON_NODE_TYPES = "jnt:manageRoles";
 
-    /**
-     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any one of
-     * them on the main resource may render the component.
-     *
-     * @param requiredPermissions comma-separated list of permission names
-     */
-    public void setRequiredPermissions(String requiredPermissions) {
-        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
-        for (int i = 0; i < parsed.length; i++) {
-            parsed[i] = parsed[i].trim();
-        }
-        this.requiredPermissions = parsed;
-        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+
+    @Activate
+    public void activate() {
+        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
+        // differently-privileged caller could later be served.
+        setPriority(22);
+        setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
+        logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        if (requiredPermissions.length == 0) {
-            logger.error("No permission configured for {}; refusing to render {}",
-                    getClass().getName(), resource.getNodePath());
-            return StringUtils.EMPTY;
-        }
-
         Resource mainResource = renderContext.getMainResource();
         JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
+            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
+            // is an administration capability.
             logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : requiredPermissions) {
+        for (String permission : REQUIRED_PERMISSIONS) {
             if (contextNode.hasPermission(permission)) {
                 return null;
             }
@@ -100,7 +124,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         if (logger.isWarnEnabled()) {
             logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
                     renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    requiredPermissionsLabel, contextNode.getPath());
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
@@ -92,10 +92,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
-        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
-        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
-        // differently-privileged caller could later be served.
-        setPriority(22);
+        // Priority 21.5: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // clear of the 22.x template band. AbstractFilter breaks a priority tie on the class name, so an exact
+        // 22 would order this against core's templateNodeFilter (22.0) by an accident of package naming rather
+        // than by intent; 21.5 states the intended slot instead of relying on that.
+        // This runs inside the fragment cache's generation scope (live only, 16 / 16.5), which is safe because
+        // that cache keys on the caller's ACL signature: an entry generated for an administrator is not served
+        // to a caller who lacks the grant.
+        setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
         setDescription("Renders a settings component only for a caller holding an administration permission "
                 + "on the main resource");

--- a/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
@@ -52,13 +52,11 @@ import java.util.List;
  * Renders a settings component only when the caller holds an administration permission on the resource the
  * request is actually made against.
  * <p>
- * The role-management screen is an ordinary, instantiable content type, so the settings container it was
- * designed for is not the only place it can be rendered from. The permission requirement is declared on the
- * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}), so it is a property of that
- * template and not of the component: the same component rendered through any other resource — a plain page
- * content area — carries no requirement at all, and the web flow behind it would be handed to whoever can
- * render that resource. This filter makes the requirement a property of the component, so it holds on every
- * render path.
+ * The permission requirement belongs on the component, not only on the settings template that normally
+ * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
+ * and hold on every render path, regardless of where the component is placed. This filter makes the
+ * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
+ * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
  * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings

--- a/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/defaultmodule/SettingsComponentPermissionFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.defaultmodule;
+
+import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders a settings component only when the caller holds an administration permission on the
+ * resource the request is actually made against.
+ * <p>
+ * The role-management screen is an ordinary, instantiable content type, so the settings container it was
+ * designed for is not the only place it can be rendered from. The permission requirement is declared on the
+ * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}) and is therefore a property of
+ * that template: the same component rendered through any other resource — a plain page content area — carries
+ * no requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
+ * filter makes the requirement a property of the component, so it holds on every render path.
+ * <p>
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and for this screen that is essential rather than incidental. {@code jnt:manageRoles} is hosted by
+ * <em>both</em> administration routes — siteSettings registers it as {@code roleGroup="site-role"} under
+ * {@code siteAdminSiteRoles}, serverSettings as server- and system-role — so a site-scoped administrator is a
+ * legitimate caller. Their role is granted on {@code /sites/<key>}, while the component node of the
+ * legitimate screen lives inside the hosting module ({@code /modules/...}), where they hold nothing. Checking
+ * the component node would therefore refuse them; the main resource is the site (or the global settings node
+ * for the server route), which is what each administrator role is actually granted on.
+ * <p>
+ * Either administration permission is accepted for the same reason. Both are core permissions
+ * ({@code root-permissions.xml}) granted by the {@code site-administrator} / {@code server-administrator}
+ * roles; the finer per-screen requirement remains enforced on the administration route by the template, so
+ * this filter is an additional condition and never a replacement. Failing to resolve a main resource, or a
+ * missing configuration, yields an empty fragment rather than a rendered component.
+ */
+// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines equality as
+// (concrete class, priority), which is the key RenderService.addFilter uses to replace an already-registered
+// filter. Widening it to the configuration would break that re-registration.
+@SuppressWarnings("java:S2160")
+public class SettingsComponentPermissionFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
+
+    private String[] requiredPermissions = new String[0];
+    private String requiredPermissionsLabel = "";
+
+    /**
+     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any one of
+     * them on the main resource may render the component.
+     *
+     * @param requiredPermissions comma-separated list of permission names
+     */
+    public void setRequiredPermissions(String requiredPermissions) {
+        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
+        for (int i = 0; i < parsed.length; i++) {
+            parsed[i] = parsed[i].trim();
+        }
+        this.requiredPermissions = parsed;
+        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    }
+
+    @Override
+    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (requiredPermissions.length == 0) {
+            logger.error("No permission configured for {}; refusing to render {}",
+                    getClass().getName(), resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : requiredPermissions) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
+            }
+        }
+
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    requiredPermissionsLabel, contextNode.getPath());
+        }
+        return StringUtils.EMPTY;
+    }
+}

--- a/src/main/resources/META-INF/spring/mod-default.xml
+++ b/src/main/resources/META-INF/spring/mod-default.xml
@@ -173,6 +173,18 @@
         <property name="applyOnConfigurations" value="module" />
     </bean>
 
+    <!-- The role-management screen is reached from the site-scoped administration route (main resource:
+         the site) and from the server-wide one (main resource: the global settings node), so either
+         administration permission is accepted. -->
+    <bean id="settingsComponentPermissionFilter"
+          class="org.jahia.modules.defaultmodule.SettingsComponentPermissionFilter">
+        <property name="priority" value="22"/>
+        <property name="description"
+                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
+        <property name="applyOnNodeTypes" value="jnt:manageRoles"/>
+        <property name="requiredPermissions" value="site-admin,admin"/>
+    </bean>
+
     <util:map id="defaultModuleProperties">
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>

--- a/src/main/resources/META-INF/spring/mod-default.xml
+++ b/src/main/resources/META-INF/spring/mod-default.xml
@@ -173,18 +173,6 @@
         <property name="applyOnConfigurations" value="module" />
     </bean>
 
-    <!-- The role-management screen is reached from the site-scoped administration route (main resource:
-         the site) and from the server-wide one (main resource: the global settings node), so either
-         administration permission is accepted. -->
-    <bean id="settingsComponentPermissionFilter"
-          class="org.jahia.modules.defaultmodule.SettingsComponentPermissionFilter">
-        <property name="priority" value="22"/>
-        <property name="description"
-                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
-        <property name="applyOnNodeTypes" value="jnt:manageRoles"/>
-        <property name="requiredPermissions" value="site-admin,admin"/>
-    </bean>
-
     <util:map id="defaultModuleProperties">
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>


### PR DESCRIPTION
## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. The role-management screen is an ordinary, instantiable content type, so the requirement is made a property of the component.

## Change

A render filter (`SettingsComponentPermissionFilter`, priority 21.5) applied on `jnt:manageRoles`, registered via
**OSGi Declarative Services**. When the caller holds none of the accepted permissions it returns an empty
fragment — core's own semantics in `TemplatePermissionCheckFilter`. Because `WebflowAction` re-enters the
render chain for each webflow POST, every transition is covered too, not just the initial GET.

**The check is evaluated on the render's MAIN RESOURCE, not on the component node.** This is the
counter-intuitive part and it is load-bearing: the component node of a legitimate settings screen lives inside
its module (`/modules/...`), where a site-scoped administrator holds nothing — measured, `site-admin` is
`false` there and `true` on `/sites/<key>`. Checking the component node, which is the obvious implementation,
would refuse real site administrators. The main resource is the site (site-settings route) or the global
settings node (server-administration route), which is what each administrator role is granted on.

Either `site-admin` or `admin` is accepted: this screen is reached from both administration routes, so a
site-scoped administrator is a legitimate caller. Both are core permissions (`root-permissions.xml`) granted by
the `site-administrator` / `server-administrator` roles. The finer per-screen permissions are contributed by a
module's own `permissions.xml` and resolve to `false` where they are not registered on an instance, which would
fail closed for administrators too; the finer requirement still applies on the administration route via the
template, so this is an additional condition and never a replacement.

For this screen that is not a nicety: siteSettings registers it as `roleGroup="site-role"` under `siteAdminSiteRoles` and serverSettings as server- and system-role, so both administrator kinds are legitimate callers.

## Verification

Measured on 8.2.4.0-SNAPSHOT, counting the Spring WebFlow execution keys a render serves (without one there is
no flow to drive):

| caller | flow served |
|---|---|
| `root` | yes |
| server administrator | yes |
| administrator of the hosting site | **yes** — a legitimate caller for this screen |
| ordinary editor | no |

Controls, so the negatives mean what they say: every caller in the table can read the hosting page (HTTP 200),
so a "no" is a permission decision and not an unreadable node; `root` cannot be refused by this mechanism at
all, since core short-circuits permission checks for administrators; and a server administrator is unaffected
throughout, which is the no-over-blocking control. 

## Notes

- Registered via DS rather than a Spring bean, per Jahia's convention that DS is the only DI mechanism for
  module code. Both routes register into `JahiaTemplateManagerService.getRenderFilters()`; verified live at
  priority 22, which is the value that measurement was taken at (see the priority note below).
- `equals`/`hashCode` are deliberately not overridden: `AbstractFilter` defines equality as
  (concrete class, priority), which is the key `RenderService.addFilter` uses to replace an already-registered
  filter. Widening it would break that re-registration.
- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this filter does
  not. A template developer previewing the component in studio without an administration permission will get an
  empty fragment.

- Placement is deliberately left unconstrained in the nodetype definitions. The condition holds wherever the
  component renders, so a definition-level restriction would be belt-and-braces rather than the load-bearing
  control. Recorded here so it does not read as an oversight.
- Priority is 21.5, not 22. An exact 22 tied with core's `templateNodeFilter` (22.0); `AbstractFilter` breaks
  such a tie on the class name, so the resulting order held by an accident of package naming. 21.5 states the
  intended slot — immediately after core's permission check at 21, clear of the 22.x template band — directly.
  No behavioural change: 22 already ordered ahead of `templateNodeFilter`.
